### PR TITLE
Jinja2 macros demo'd via test_debounce.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-Smax, pronounced "smash," is a DSL for implementing Harel state machines with a python3 back end.
+Smax, pronounced "smash," is a DSL for implementing Harel (heirarchical) state machines with a python3 back end.
 
 Smax translates a state machine specification into python code which you can import, subclass, and execute.  The state machine specification is usually given between special tags in the python module that uses it; but the specification can come from a literal string or an input file.
 
@@ -292,7 +292,10 @@ Additional parallel state machine notes:
 
 ## Macros
 
-(This work is underway.)
+Frequently, the same state machine patterns occur in multiple places within your system.  For example, consider a design with multiple input switches, all of which are noisy and need debouncing.  A very reasonable approach is to have a "Debouncer" state machine, instantiated once for each switch; specific switch updates are sent to the same named method on a specific instance; that instance would know how to send out the debounced state of that input.
+
+But consider another technique for handling this situation, which is to use a macro text substitution tool to replicate the pattern in a parent state machine.  In this case, each debouncer would run as a parallel machine within a parent state machine.  When a switch change is seen, instead of calling a common method on a specific state machine instance (as above), you'd call the switch-specific event on the parent state machine instance.  Because all active parallel machines receive all the machine's events, the debouncer now can also pay attention to global events sent to that machine (e.g. "ev_reset"); passing along debouncer results to the parent state machine becomes easy (e.g. "self.ev_switch_a_active()"); and the entire debouncer mechanism can be activated and deactivated on demand (in the same way the serial port above is deactivated when the USB controller is unplugged above).  For an example of using Jinja2 in this way, check out test/test_debounce.py.
+
 
 # API
 

--- a/examples/intro.py
+++ b/examples/intro.py
@@ -63,28 +63,6 @@ with open("/tmp/intro_state_machine.py", "wt") as f:
 module = smax.compile_python(python_source)
 MyStateMachine = module.MyStateMachine
 
-# This is the most complicated way but translates the
-# source code in such a way that you can step through
-# it with e.g. pudb.
-def generated_python_python(s):  # noqa: E302
-    with open(".generated_state_machine.py", "wt") as f:
-        f.write(s)
-
-
-smax.load(  # noqa: E305
-    __file__,
-    "MyStateMachine",
-    save_generated_python=generated_python_python,
-)
-import importlib.util  # noqa: E402
-
-spec = importlib.util.spec_from_file_location(
-    "state_machine", ".generated_state_machine.py"
-)
-m = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(m)
-MyStateMachine = m.MyStateMachine
-
 
 class MyDevice(MyStateMachine):
     def __init__(self, reactor):


### PR DESCRIPTION
Using jinja2 to substitute in state machine sections presents a powerful technique for reusing patterns in state machines.