### PR TITLE
Update reactor to use monotonic time; support "from ... import ..." statements

### DIFF
--- a/smax/parser.py
+++ b/smax/parser.py
@@ -102,6 +102,7 @@ parser state_machine:
     token PASS: "pass"
     token ENTER: "enter"
     token EXIT: "exit"
+    token FROM: "from"
     token IMPORT: "import"
     token IS: "is"
     token START: "\\*"
@@ -137,7 +138,9 @@ parser state_machine:
         NAME '=' TOEOL {{ return spec.constant(NAME.strip(), TOEOL.strip()) }}
 
     rule import_<<spec>>:
-        IMPORT TOEOL {{ return spec.import_("import %s" % TOEOL.strip()) }}
+        (   IMPORT TOEOL {{ return spec.import_("import %s" % TOEOL.strip()) }}
+        |   FROM TOEOL {{ return spec.import_("from %s" % TOEOL.strip()) }}
+        )
 
     rule machine<<spec>>:
         {{ superclass = "object" }}
@@ -186,7 +189,6 @@ parser state_machine:
         {{ condition=None }}
         {{ state_target=None }}
         {{ code_clause=None }}
-        {{ state_target=None }}
         {{ superclasses=[ ] }}
         event_name
             ( OPEN_PAREN event_args CLOSE_PAREN )?

--- a/smax/reactor.py
+++ b/smax/reactor.py
@@ -26,7 +26,7 @@ class Reactor(object):
                 cb(*args)
                 continue
             timeout = None
-            now = time.time()
+            now = time.monotonic()
             if self._alarms:
                 trigger, cb, args = self._alarms[0]
                 if trigger <= now:
@@ -44,7 +44,7 @@ class Reactor(object):
         self._signal()
 
     def after_s(self, seconds, callback, *args):
-        trigger = time.time() + seconds
+        trigger = time.monotonic() + seconds
         r = (trigger, callback, args)
         log.trace("after_s cb=%s." % callback)
         self._alarms.append(r)


### PR DESCRIPTION
Because times within the state machine spec are relative--s(...) and ms(...) are from the time they're called--it only makes sense to use monotonic time for the backend.  Also, import statements are supported within your machine spec; we now record any line that starts with the word "from ..." as a user-specified import too.